### PR TITLE
introduced a fix for gaussian kernel and ksample interaction

### DIFF
--- a/hyppo/_utils.py
+++ b/hyppo/_utils.py
@@ -109,6 +109,8 @@ def gaussian(x, workers=None):
             l1, (n - 1, n + 1), (l1.itemsize * (n + 1), l1.itemsize)
         )[:, 1:]
     )
+    # prevents division when used on label vectors
+    med = med if med else 1
     gamma = 1.0 / (2 * (med ** 2))
     return rbf_kernel(x, gamma=gamma)
 

--- a/hyppo/_utils.py
+++ b/hyppo/_utils.py
@@ -109,7 +109,7 @@ def gaussian(x, workers=None):
             l1, (n - 1, n + 1), (l1.itemsize * (n + 1), l1.itemsize)
         )[:, 1:]
     )
-    # prevents division when used on label vectors
+    # prevents division by zero when used on label vectors
     med = med if med else 1
     gamma = 1.0 / (2 * (med ** 2))
     return rbf_kernel(x, gamma=gamma)


### PR DESCRIPTION
#### Reference issue
Fixes #92 

#### Type of change
Bug fix.
<!--Bug, Documentation, Feature Request-->

#### What does this implement/fix? 
prevents division by zero when the following three conditions hold:
- Ksample test is used
- metric is medial gaussian kernel
- two samples are of (substantially?) different size

#### Additional information
<!--Any additional information you think is important.-->