### PR TITLE
Restricted permutation functionality for Dcorr

### DIFF
--- a/hyppo/_utils.py
+++ b/hyppo/_utils.py
@@ -6,7 +6,6 @@ from scipy.stats.distributions import chi2
 from sklearn.metrics import pairwise_distances
 from sklearn.metrics.pairwise import rbf_kernel
 
-
 # from scipy
 def contains_nan(a):
     """Check if inputs contains NaNs"""
@@ -61,7 +60,7 @@ def check_reps(reps):
     elif reps < 1000:
         msg = (
             "The number of replications is low (under 1000), and p-value "
-            "calculations may be unreliable. Use the p-value result with "
+            "calculations may be unreliable. Use the p-value result, with "
             "caution!"
         )
         warnings.warn(msg, RuntimeWarning)
@@ -109,25 +108,157 @@ def gaussian(x, workers=None):
             l1, (n - 1, n + 1), (l1.itemsize * (n + 1), l1.itemsize)
         )[:, 1:]
     )
-    # prevents division by zero when used on label vectors
-    med = med if med else 1
     gamma = 1.0 / (2 * (med ** 2))
     return rbf_kernel(x, gamma=gamma)
 
 
+def check_perm_blocks(perm_blocks):
+    # Checks generic properties of perm_blocks
+    if perm_blocks is None:
+        return None
+    elif isinstance(perm_blocks, list):
+        perm_blocks = np.asarray(perm_blocks)
+    elif not isinstance(perm_blocks, np.ndarray):
+        raise TypeError("perm_blocks must be an ndarray or list")
+    if perm_blocks.ndim == 1:
+        perm_blocks = perm_blocks[:, np.newaxis]
+    elif perm_blocks.ndim > 2:
+        raise ValueError("perm_blocks must be of at most dimension 2")
+
+    return perm_blocks
+
+
+def check_perm_blocks_dim(perm_blocks, y):
+    if not perm_blocks.shape[0] == y.shape[0]:
+        raise ValueError(f"perm_bocks first dimension must be same length as y")
+
+
+def check_perm_block(perm_block):
+    # checks a hierarchy level of perm_blocks for proper exchangeability
+    if not isinstance(perm_block[0], int):
+        unique, perm_blocks, counts = np.unique(
+            perm_block, return_counts=True, return_inverse=True
+        )
+    else:
+        unique, counts = np.unique(perm_block, return_counts=True)
+    pos_counts = [c for c, u in zip(counts, unique) if u >= 0]
+    if len(set(pos_counts)) > 1:
+        raise ValueError(
+            f"Exchangeable hiearchy has groups with {min(pos_counts)} to \
+                {max(pos_counts)} elements"
+        )
+
+    return perm_block
+    
+
+class _PermNode(object):
+    """
+    Helper class for nodes in _PermTree.
+    """
+    def __init__(self, parent, label=None, index=None):
+        self.children = []
+        self.parent = parent
+        self.label = label
+        self.index = index
+
+    def get_leaf_indices(self):
+        if len(self.children) == 0:
+            return [self.index]
+        else:
+            indices = []
+            for child in self.children:
+                indices += child.get_leaf_indices()
+            return indices
+
+    def add_child(self, child):
+        self.children.append(child)
+
+    def get_children(self):
+        return self.children
+
+
+class _PermTree(object):
+    """
+    Tree representation of dependencies for restricted permutations
+    """
+    def __init__(self, perm_blocks):
+        perm_blocks = check_perm_blocks(perm_blocks)
+        self.root = _PermNode(None)
+        self._add_levels(self.root, perm_blocks, np.arange(perm_blocks.shape[0]))
+        indices = self.root.get_leaf_indices()
+        self._index_order = np.argsort(indices)
+
+    def _add_levels(self, root: _PermNode, perm_blocks, indices):
+        # Add new child node for each unique label, then recurse or end
+        if perm_blocks.shape[1] == 0:
+            for idx in indices:
+                child_node = _PermNode(parent=root, label=1, index=idx)
+                root.add_child(child_node)
+        else:
+            perm_block = check_perm_block(perm_blocks[:, 0])
+            for label in np.unique(perm_block):
+                idxs = np.where(perm_block == label)[0]
+                child_node = _PermNode(parent=root, label=label)
+                root.add_child(child_node)
+                self._add_levels(child_node, perm_blocks[idxs, 1:], indices[idxs])
+
+    def _permute_level(self, node):
+        if len(node.get_children()) == 0:
+            return [node.index]
+        else:
+            indices, labels = zip(*[(self._permute_level(child), child.label) for child in node.get_children()])
+            shuffle_children = [i for i, label in enumerate(labels) if label >= 0]
+            indices = np.asarray(indices)
+            if len(shuffle_children) > 1:
+                indices[shuffle_children] = indices[np.random.permutation(shuffle_children)]
+            return np.concatenate(indices)
+
+    def permute_indices(self):
+        return self._permute_level(self.root)[self._index_order]
+
+    def original_indices(self):
+        return np.arange(len(self._index_order))
+
+
+# permutation group shuffling class
+class _PermGroups(object):
+    """
+    Helper function to calculate parallel p-value.
+    """
+    def __init__(self, y, perm_blocks=None):
+        self.n = y.shape[0]
+        if perm_blocks is None:
+            self.perm_tree = None
+        else:
+            self.perm_tree = _PermTree(perm_blocks)
+
+    def __call__(self):
+        if self.perm_tree is None:
+            order = np.random.permutation(self.n)
+        else:
+            order = self.perm_tree.permute_indices()
+
+        return order
+
+
 # p-value computation
-def _perm_stat(calc_stat, x, y, is_distsim=True):
-    if is_distsim:
+def _perm_stat(calc_stat, x, y, is_distsim=True, permuter=None):
+    if permuter is None:
         order = np.random.permutation(y.shape[0])
+    else:
+        order = permuter()
+
+    if is_distsim:
         permy = y[order][:, order]
     else:
-        permy = np.random.permutation(y)
+        permy = y[order]
+
     perm_stat = calc_stat(x, permy)
 
     return perm_stat
 
 
-def perm_test(calc_stat, x, y, reps=1000, workers=1, is_distsim=True):
+def perm_test(calc_stat, x, y, reps=1000, workers=1, is_distsim=True, perm_blocks=None):
     """
     Calculate the p-value via permutation
     """
@@ -135,9 +266,10 @@ def perm_test(calc_stat, x, y, reps=1000, workers=1, is_distsim=True):
     stat = calc_stat(x, y)
 
     # calculate null distribution
+    permuter = _PermGroups(y, perm_blocks)
     null_dist = np.array(
         Parallel(n_jobs=workers)(
-            [delayed(_perm_stat)(calc_stat, x, y, is_distsim) for rep in range(reps)]
+            [delayed(_perm_stat)(calc_stat, x, y, is_distsim, permuter) for rep in range(reps)]
         )
     )
     pvalue = (null_dist >= stat).sum() / reps

--- a/hyppo/_utils.py
+++ b/hyppo/_utils.py
@@ -149,12 +149,13 @@ def check_perm_block(perm_block):
         )
 
     return perm_block
-    
+
 
 class _PermNode(object):
     """
     Helper class for nodes in _PermTree.
     """
+
     def __init__(self, parent, label=None, index=None):
         self.children = []
         self.parent = parent
@@ -181,6 +182,7 @@ class _PermTree(object):
     """
     Tree representation of dependencies for restricted permutations
     """
+
     def __init__(self, perm_blocks):
         perm_blocks = check_perm_blocks(perm_blocks)
         self.root = _PermNode(None)
@@ -206,11 +208,18 @@ class _PermTree(object):
         if len(node.get_children()) == 0:
             return [node.index]
         else:
-            indices, labels = zip(*[(self._permute_level(child), child.label) for child in node.get_children()])
+            indices, labels = zip(
+                *[
+                    (self._permute_level(child), child.label)
+                    for child in node.get_children()
+                ]
+            )
             shuffle_children = [i for i, label in enumerate(labels) if label >= 0]
             indices = np.asarray(indices)
             if len(shuffle_children) > 1:
-                indices[shuffle_children] = indices[np.random.permutation(shuffle_children)]
+                indices[shuffle_children] = indices[
+                    np.random.permutation(shuffle_children)
+                ]
             return np.concatenate(indices)
 
     def permute_indices(self):
@@ -225,6 +234,7 @@ class _PermGroups(object):
     """
     Helper function to calculate parallel p-value.
     """
+
     def __init__(self, y, perm_blocks=None):
         self.n = y.shape[0]
         if perm_blocks is None:
@@ -269,7 +279,10 @@ def perm_test(calc_stat, x, y, reps=1000, workers=1, is_distsim=True, perm_block
     permuter = _PermGroups(y, perm_blocks)
     null_dist = np.array(
         Parallel(n_jobs=workers)(
-            [delayed(_perm_stat)(calc_stat, x, y, is_distsim, permuter) for rep in range(reps)]
+            [
+                delayed(_perm_stat)(calc_stat, x, y, is_distsim, permuter)
+                for rep in range(reps)
+            ]
         )
     )
     pvalue = (null_dist >= stat).sum() / reps

--- a/hyppo/discrim/_utils.py
+++ b/hyppo/discrim/_utils.py
@@ -42,7 +42,7 @@ class _CheckInputs:
 
     def _condition_input(self, x1):
         """Checks whether there is only one subject and removes
-           isolates and calculate distance."""
+        isolates and calculate distance."""
         uniques, counts = np.unique(self.y, return_counts=True)
 
         if (counts != 1).sum() <= 1:

--- a/hyppo/discrim/tests/test_discrim_one_samp.py
+++ b/hyppo/discrim/tests/test_discrim_one_samp.py
@@ -33,8 +33,7 @@ class TestOneSample:
 
 
 class TestOneSampleWarn:
-    """ Tests errors and warnings derived from one sample test.
-    """
+    """Tests errors and warnings derived from one sample test."""
 
     def test_error_one_id(self):
         # checks whether y has only one id

--- a/hyppo/independence/base.py
+++ b/hyppo/independence/base.py
@@ -38,7 +38,7 @@ class IndependenceTest(ABC):
         """
 
     @abstractmethod
-    def test(self, x, y, reps=1000, workers=1, is_distsim=True):
+    def test(self, x, y, reps=1000, workers=1, is_distsim=True, perm_blocks=None):
         r"""
         Calulates the independence test p-value.
 
@@ -51,6 +51,11 @@ class IndependenceTest(ABC):
         workers : int, optional (default: 1)
             Evaluates method using `multiprocessing.Pool <multiprocessing>`).
             Supply `-1` to use all cores available to the Process.
+        perm_blocks : 2d ndarray, optional
+            Restricts permutations to account for dependencies in data. Columns
+            recursively partition samples based on unique labels. Groups at
+            each partition are exchangeable under a permutation but remain
+            fixed if label is negative.
 
         Returns
         -------
@@ -64,7 +69,7 @@ class IndependenceTest(ABC):
 
         # calculate p-value
         stat, pvalue, null_dist = perm_test(
-            self._statistic, x, y, reps=reps, workers=workers, is_distsim=is_distsim
+            self._statistic, x, y, reps=reps, workers=workers, is_distsim=is_distsim, perm_blocks=perm_blocks
         )
         self.stat = stat
         self.pvalue = pvalue

--- a/hyppo/independence/base.py
+++ b/hyppo/independence/base.py
@@ -69,7 +69,13 @@ class IndependenceTest(ABC):
 
         # calculate p-value
         stat, pvalue, null_dist = perm_test(
-            self._statistic, x, y, reps=reps, workers=workers, is_distsim=is_distsim, perm_blocks=perm_blocks
+            self._statistic,
+            x,
+            y,
+            reps=reps,
+            workers=workers,
+            is_distsim=is_distsim,
+            perm_blocks=perm_blocks,
         )
         self.stat = stat
         self.pvalue = pvalue

--- a/hyppo/independence/dcorr.py
+++ b/hyppo/independence/dcorr.py
@@ -224,7 +224,7 @@ class Dcorr(IndependenceTest):
         return stat, pvalue
 
 
-#@njit
+@njit
 def _center_distmat(distx, bias):  # pragma: no cover
     """Centers the distance matrices"""
     n = distx.shape[0]
@@ -247,7 +247,7 @@ def _center_distmat(distx, bias):  # pragma: no cover
     return cent_distx
 
 
-#@njit
+@njit
 def _dcorr(distx, disty, bias):  # pragma: no cover
     """Calculate the Dcorr test statistic"""
     # center distance matrices

--- a/hyppo/independence/dcorr.py
+++ b/hyppo/independence/dcorr.py
@@ -219,7 +219,9 @@ class Dcorr(IndependenceTest):
                 x = self.compute_distance(x, workers=workers)
                 y = self.compute_distance(y, workers=workers)
                 self.is_distance = True
-            stat, pvalue = super(Dcorr, self).test(x, y, reps, workers, perm_blocks=perm_blocks)
+            stat, pvalue = super(Dcorr, self).test(
+                x, y, reps, workers, perm_blocks=perm_blocks
+            )
 
         return stat, pvalue
 

--- a/hyppo/independence/dcorr.py
+++ b/hyppo/independence/dcorr.py
@@ -1,7 +1,8 @@
 import numpy as np
+from collections import defaultdict
 from numba import njit
 
-from .._utils import euclidean, check_xy_distmat, chi2_approx
+from .._utils import euclidean, check_xy_distmat, chi2_approx, check_perm_blocks_dim
 from .base import IndependenceTest
 from ._utils import _CheckInputs
 
@@ -129,7 +130,7 @@ class Dcorr(IndependenceTest):
 
         return stat
 
-    def test(self, x, y, reps=1000, workers=1, auto=True, bias=False):
+    def test(self, x, y, reps=1000, workers=1, auto=True, bias=False, perm_blocks=None):
         r"""
         Calculates the Dcorr test statistic and p-value.
 
@@ -152,6 +153,11 @@ class Dcorr(IndependenceTest):
             is greater than 20. If True, and sample size is greater than 20, a fast
             chi2 approximation will be run. Parameters ``reps`` and ``workers`` are
             irrelevant in this case.
+        perm_blocks : list or ndarray, optional
+            Provides hierarchy of dependencies to restrict permutations. Columns
+            provide labels for each sample and recursively partition. Groups at
+            each partition are exchangeable under a permutation but remain
+            fixed if label is negative.
 
         Returns
         -------
@@ -198,11 +204,12 @@ class Dcorr(IndependenceTest):
             x, y, reps=reps, compute_distance=self.compute_distance
         )
         x, y = check_input()
-
         if self.is_distance:
             check_xy_distmat(x, y)
+        if perm_blocks is not None:
+            check_perm_blocks_dim(perm_blocks, y)
 
-        if auto and x.shape[0] > 20:
+        if auto and x.shape[0] > 20 and perm_blocks is None:
             stat, pvalue = chi2_approx(self._statistic, x, y)
             self.stat = stat
             self.pvalue = pvalue
@@ -212,17 +219,15 @@ class Dcorr(IndependenceTest):
                 x = self.compute_distance(x, workers=workers)
                 y = self.compute_distance(y, workers=workers)
                 self.is_distance = True
-            stat, pvalue = super(Dcorr, self).test(x, y, reps, workers)
+            stat, pvalue = super(Dcorr, self).test(x, y, reps, workers, perm_blocks=perm_blocks)
 
         return stat, pvalue
 
 
-@njit
+#@njit
 def _center_distmat(distx, bias):  # pragma: no cover
     """Centers the distance matrices"""
     n = distx.shape[0]
-
-    # double centered distance matrices
     if bias:
         # use sum instead of mean because of numba restrictions
         exp_distx = (
@@ -239,11 +244,10 @@ def _center_distmat(distx, bias):  # pragma: no cover
     cent_distx = distx - exp_distx
     if not bias:
         np.fill_diagonal(cent_distx, 0)
-
     return cent_distx
 
 
-@njit
+#@njit
 def _dcorr(distx, disty, bias):  # pragma: no cover
     """Calculate the Dcorr test statistic"""
     # center distance matrices

--- a/hyppo/independence/tests/test_cca.py
+++ b/hyppo/independence/tests/test_cca.py
@@ -31,8 +31,7 @@ class TestCCAStat:
 
 
 class TestCCAErrorWarn:
-    """ Tests errors and warnings derived from MGC.
-    """
+    """Tests errors and warnings derived from MGC."""
 
     def test_error_notndarray(self):
         # raises error if x or y is not a ndarray

--- a/hyppo/independence/tests/test_dcorr.py
+++ b/hyppo/independence/tests/test_dcorr.py
@@ -20,8 +20,7 @@ class TestDcorrStat:
 
 
 class TestDcorrErrorWarn:
-    """ Tests errors and warnings derived from MGC.
-    """
+    """Tests errors and warnings derived from MGC."""
 
     def test_error_notndarray(self):
         # raises error if x or y is not a ndarray

--- a/hyppo/independence/tests/test_hhg.py
+++ b/hyppo/independence/tests/test_hhg.py
@@ -21,8 +21,7 @@ class TestHHGStat:
 
 
 class TestHHGErrorWarn:
-    """ Tests errors and warnings derived from MGC.
-    """
+    """Tests errors and warnings derived from MGC."""
 
     def test_error_notndarray(self):
         # raises error if x or y is not a ndarray

--- a/hyppo/independence/tests/test_hsic.py
+++ b/hyppo/independence/tests/test_hsic.py
@@ -20,8 +20,7 @@ class TestHsicStat:
 
 
 class TestHsicErrorWarn:
-    """ Tests errors and warnings derived from MGC.
-    """
+    """Tests errors and warnings derived from MGC."""
 
     def test_error_notndarray(self):
         # raises error if x or y is not a ndarray

--- a/hyppo/independence/tests/test_mgc.py
+++ b/hyppo/independence/tests/test_mgc.py
@@ -7,8 +7,7 @@ from .. import MGC
 
 
 class TestMGCStat(object):
-    """ Test validity of MGC test statistic
-    """
+    """Test validity of MGC test statistic"""
 
     @pytest.mark.parametrize(
         "sim, obs_stat, obs_pvalue",

--- a/hyppo/independence/tests/test_rvcorr.py
+++ b/hyppo/independence/tests/test_rvcorr.py
@@ -20,8 +20,7 @@ class TestRVStat:
 
 
 class TestRVErrorWarn:
-    """ Tests errors and warnings derived from MGC.
-    """
+    """Tests errors and warnings derived from MGC."""
 
     def test_error_notndarray(self):
         # raises error if x or y is not a ndarray

--- a/hyppo/ksample/tests/test_ksamp.py
+++ b/hyppo/ksample/tests/test_ksamp.py
@@ -22,8 +22,7 @@ class TestKSample:
 
 
 class TestKSampleErrorWarn:
-    """ Tests errors and warnings derived from MGC.
-    """
+    """Tests errors and warnings derived from MGC."""
 
     def test_error_notndarray(self):
         # raises error if x or y is not a ndarray

--- a/hyppo/tests/test_utils.py
+++ b/hyppo/tests/test_utils.py
@@ -1,0 +1,65 @@
+from hyppo._utils import _PermTree, _PermNode
+from numpy.testing import assert_array_less, assert_allclose, assert_equal
+import numpy as np
+
+
+class TestPermTree:
+    """
+    Tests that permutations are restricted correctly
+    """
+
+    def test_within_permutatins(self):
+        np.random.seed(1)
+        #i.e. case: y = np.asarray([0,1,0,1,0,1])
+        blocks = np.vstack((
+            [-1, 1],
+            [-1, 2],
+            [-2, 1],
+            [-2, 2],
+            [-3, 1],
+            [-3, 2],
+        ))
+        perm_tree = _PermTree(blocks)
+        original_indices = perm_tree.original_indices()
+        perms = np.asarray([
+            perm_tree.permute_indices() for _ in range(10)
+        ])
+        assert_array_less(np.abs(original_indices - perms), 2)
+        assert_allclose(np.mean(perms, axis=0), [0.5, 0.5, 2.5, 2.5, 4.5, 4.5], rtol=0, atol=0.2)
+
+    def test_across_permutations(self):
+        np.random.seed(0)
+        y = np.asarray([
+            0,0,1,1,2,2
+        ])
+        blocks = np.vstack((
+            [1, -1],
+            [1, -2],
+            [2, -1],
+            [2, -2],
+            [3, -1],
+            [3, -2],
+        ))
+        perm_tree = _PermTree(blocks)
+        original_indices = perm_tree.original_indices()
+        perms = np.asarray([
+            perm_tree.permute_indices() for _ in range(100)
+        ])
+        assert_equal(perms[0][1::2] - perms[0][::2], [1,1,1])
+        assert_allclose(np.mean(perms, axis=0), [2, 3, 2, 3, 2, 3], rtol=0, atol=0.2)
+
+    def test_fixed_permutation(self):
+        np.random.seed(0)
+        blocks = [-1,-2,-3,-4]
+        perm_tree = _PermTree(blocks)
+        assert_equal(perm_tree.permute_indices(), perm_tree.original_indices())
+
+    def test_semifixed(self):
+        np.random.seed(1)
+        blocks = [1,2,-3,-4]
+        perm_tree = _PermTree(blocks)
+        perms = np.asarray([
+            perm_tree.permute_indices() for _ in range(10)
+        ])
+        assert_equal(perms[0][2:], perm_tree.original_indices()[2:])
+        assert_allclose(np.mean(perms, axis=0)[:2], [0.5, 0.5], rtol=0, atol=0.2)

--- a/hyppo/tests/test_utils.py
+++ b/hyppo/tests/test_utils.py
@@ -10,56 +10,36 @@ class TestPermTree:
 
     def test_within_permutatins(self):
         np.random.seed(1)
-        #i.e. case: y = np.asarray([0,1,0,1,0,1])
-        blocks = np.vstack((
-            [-1, 1],
-            [-1, 2],
-            [-2, 1],
-            [-2, 2],
-            [-3, 1],
-            [-3, 2],
-        ))
+        # i.e. case: y = np.asarray([0,1,0,1,0,1])
+        blocks = np.vstack(([-1, 1], [-1, 2], [-2, 1], [-2, 2], [-3, 1], [-3, 2],))
         perm_tree = _PermTree(blocks)
         original_indices = perm_tree.original_indices()
-        perms = np.asarray([
-            perm_tree.permute_indices() for _ in range(10)
-        ])
+        perms = np.asarray([perm_tree.permute_indices() for _ in range(10)])
         assert_array_less(np.abs(original_indices - perms), 2)
-        assert_allclose(np.mean(perms, axis=0), [0.5, 0.5, 2.5, 2.5, 4.5, 4.5], rtol=0, atol=0.2)
+        assert_allclose(
+            np.mean(perms, axis=0), [0.5, 0.5, 2.5, 2.5, 4.5, 4.5], rtol=0, atol=0.2
+        )
 
     def test_across_permutations(self):
         np.random.seed(0)
-        y = np.asarray([
-            0,0,1,1,2,2
-        ])
-        blocks = np.vstack((
-            [1, -1],
-            [1, -2],
-            [2, -1],
-            [2, -2],
-            [3, -1],
-            [3, -2],
-        ))
+        y = np.asarray([0, 0, 1, 1, 2, 2])
+        blocks = np.vstack(([1, -1], [1, -2], [2, -1], [2, -2], [3, -1], [3, -2],))
         perm_tree = _PermTree(blocks)
         original_indices = perm_tree.original_indices()
-        perms = np.asarray([
-            perm_tree.permute_indices() for _ in range(100)
-        ])
-        assert_equal(perms[0][1::2] - perms[0][::2], [1,1,1])
+        perms = np.asarray([perm_tree.permute_indices() for _ in range(100)])
+        assert_equal(perms[0][1::2] - perms[0][::2], [1, 1, 1])
         assert_allclose(np.mean(perms, axis=0), [2, 3, 2, 3, 2, 3], rtol=0, atol=0.2)
 
     def test_fixed_permutation(self):
         np.random.seed(0)
-        blocks = [-1,-2,-3,-4]
+        blocks = [-1, -2, -3, -4]
         perm_tree = _PermTree(blocks)
         assert_equal(perm_tree.permute_indices(), perm_tree.original_indices())
 
     def test_semifixed(self):
         np.random.seed(1)
-        blocks = [1,2,-3,-4]
+        blocks = [1, 2, -3, -4]
         perm_tree = _PermTree(blocks)
-        perms = np.asarray([
-            perm_tree.permute_indices() for _ in range(10)
-        ])
+        perms = np.asarray([perm_tree.permute_indices() for _ in range(10)])
         assert_equal(perms[0][2:], perm_tree.original_indices()[2:])
         assert_allclose(np.mean(perms, axis=0)[:2], [0.5, 0.5], rtol=0, atol=0.2)

--- a/hyppo/tests/test_utils.py
+++ b/hyppo/tests/test_utils.py
@@ -11,7 +11,16 @@ class TestPermTree:
     def test_within_permutatins(self):
         np.random.seed(1)
         # i.e. case: y = np.asarray([0,1,0,1,0,1])
-        blocks = np.vstack(([-1, 1], [-1, 2], [-2, 1], [-2, 2], [-3, 1], [-3, 2],))
+        blocks = np.vstack(
+            (
+                [-1, 1],
+                [-1, 2],
+                [-2, 1],
+                [-2, 2],
+                [-3, 1],
+                [-3, 2],
+            )
+        )
         perm_tree = _PermTree(blocks)
         original_indices = perm_tree.original_indices()
         perms = np.asarray([perm_tree.permute_indices() for _ in range(10)])
@@ -23,7 +32,16 @@ class TestPermTree:
     def test_across_permutations(self):
         np.random.seed(0)
         y = np.asarray([0, 0, 1, 1, 2, 2])
-        blocks = np.vstack(([1, -1], [1, -2], [2, -1], [2, -2], [3, -1], [3, -2],))
+        blocks = np.vstack(
+            (
+                [1, -1],
+                [1, -2],
+                [2, -1],
+                [2, -2],
+                [3, -1],
+                [3, -2],
+            )
+        )
         perm_tree = _PermTree(blocks)
         original_indices = perm_tree.original_indices()
         perms = np.asarray([perm_tree.permute_indices() for _ in range(100)])


### PR DESCRIPTION
#### Type of change
Added feature allowing user to restrict the set of allowable permutations in Dcorr (i.e. due to known dependencies in the data, longitudinal data, repeat measurements, etc).

#### What does this implement/fix?
Adds a permutation tree class to `hyppo/_utils.py` with tests in `hyppo/tests/test_utils` that models a hierarchy of dependencies in the data.

Adds a new `perm_block` parameter to Dcorr which is passed to `perm_test` in `hyppo/_utils.py` creating the permutation tree which is then used to calculate the null distribution.

#### Additional information
Inspired by the paper [Multi-level block permutation
](https://www.sciencedirect.com/science/article/pii/S105381191500508X) which has related implementation in [FSL](https://github.com/andersonwinkler/PALM/blob/master/palm_tree.m]).