### PR TITLE
MGC redundancy warning (#125)

### DIFF
--- a/hyppo/independence/mgc.py
+++ b/hyppo/independence/mgc.py
@@ -7,6 +7,8 @@ from ..tools import compute_dist
 from ._utils import _CheckInputs
 from .base import IndependenceTest
 
+import numpy as np
+
 
 class MGCestOutput(NamedTuple):
     stat: float
@@ -164,6 +166,15 @@ class MGC(IndependenceTest):
 
         return stat
 
+    def check_redundancy(self, x, y):
+        """Check if there are redundant rows in input arrays x and y"""
+
+        combined = np.vstack([np.hstack(x), np.hstack(y)]).T
+        unique_rows = np.unique(combined, axis=0)
+        redundancy_flag = combined.shape != unique_rows.shape
+        if redundancy_flag:
+            warnings.warn("Redundant rows exist")
+
     def test(self, x, y, reps=1000, workers=1, random_state=None):
         r"""
         Calculates the MGC test statistic and p-value.
@@ -226,6 +237,8 @@ class MGC(IndependenceTest):
             reps=reps,
         )
         x, y = check_input()
+
+        self.check_redundancy(x, y)
 
         x, y = compute_dist(x, y, metric=self.compute_distance, **self.kwargs)
         self.is_distance = True

--- a/hyppo/independence/tests/test_mgc.py
+++ b/hyppo/independence/tests/test_mgc.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_almost_equal, assert_approx_equal
+from numpy.testing import assert_almost_equal, assert_approx_equal, assert_equal
 
 from ...tools import linear, multimodal_independence, power, spiral
 from .. import MGC
@@ -77,3 +77,13 @@ class TestMGCTypeIError:
         )
 
         assert_almost_equal(est_power, 0.05, decimal=2)
+
+
+class TestMGCRedundancyWarning:
+    def test_redundancy_warning(self):
+        x = np.hstack((np.arange(0, 6), 5, 5, 5, 5))
+        y = np.hstack((np.arange(0, 6), 5, 5, 5, 5))
+        with pytest.warns(UserWarning) as record:
+            MGC().test(x, y)
+        assert_equal(len(record), 1)
+        assert_equal("Redundant rows exist" in record[0].message.args[0], True)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
 Add warning when X or Y have redundant rows; close #125 
#### Type of change
<!--Bug, Documentation, Feature Request-->
Documentation
#### What does this implement/fix?
<!--Please explain your changes.-->
Added a function check_redundancy in mgc.py to check if redundancies are present in x or y and report a warning to the user.
#### Additional information
<!--Any additional information you think is important.-->
I used the following code to find if redundant rows exist
```
    def check_redundancy(self, x, y):
        """Check if there are redundant rows in input arrays x and y"""

        combined = np.vstack([np.hstack(x), np.hstack(y)]).T
        unique_rows = np.unique(combined, axis=0)
        redundancy_flag = combined.shape != unique_rows.shape
        if redundancy_flag:
            warnings.warn("Redundant rows exist")
```

Added a test in test_mgc.py for checking if UserWarning is printed successfully.