### PR TITLE
fix docstring typos

### DIFF
--- a/tutorials/independence.py
+++ b/tutorials/independence.py
@@ -370,7 +370,7 @@ plt.show()
 # As such, we see that this set of data contains 3 such runs, and again by randomizing the
 # labels of each data point we can determine the test statistic and p-value for the hypothesis
 # that to determine the randomness of our combined sample.
-# It's worth noting that X and Y have the same number of samples, just that they posess the same number of multivariate
+# It's worth noting that X and Y need not have the same number of samples, just that they posess the same number of multivariate
 # features. Lastly, labels for X and Y need not be 0 and 1, they just need be consistent across samples.
 # These tests runs like :ref:`any other test<general indep>`.
 #

--- a/tutorials/overview.py
+++ b/tutorials/overview.py
@@ -25,8 +25,8 @@ Before we get started, here are a few of the conventions we use within hyppo:
   method exists that just returns the test statistic.
 * All functions and classes accept :class:`numpy.ndarray` as inputs. Optional inputs
   vary between tests within the package.
-* Input data matrices have the shape ``(n, p)`` where `n` is the number of sample and
-  `p` is the number of dimensinos (or features)
+* Input data matrices have the shape ``(n, p)`` where `n` is the number of samples and
+  `p` is the number of dimensions (or features)
 
 The Library
 -----------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
No issue created

#### Type of change
<!--Bug, Documentation, Feature Request-->
Documentation

#### What does this implement/fix?
<!--Please explain your changes.-->
Minor Typos in Overview and Independence sections of User Guide Docs

#### Additional information
<!--Any additional information you think is important.-->