### PR TITLE
Stat ranges to docs

### DIFF
--- a/hyppo/independence/friedman_rafsky.py
+++ b/hyppo/independence/friedman_rafsky.py
@@ -83,7 +83,7 @@ class FriedmanRafsky(IndependenceTest):
         Returns
         -------
         stat : float
-            The computed Friedman Rafsky statistic.
+            The computed Friedman Rafsky statistic. 
         """
         x = np.transpose(x)
         labels = np.transpose(y)
@@ -102,7 +102,7 @@ class FriedmanRafsky(IndependenceTest):
         random_state=None,
     ):
         r"""
-        Calculates the Friedman Rafsky test statistic and p-value.
+        Calculates the Friedman Rafsky test statistic and p-value. A value between ``2`` and ``n``.
 
         Parameters
         ----------

--- a/hyppo/independence/friedman_rafsky.py
+++ b/hyppo/independence/friedman_rafsky.py
@@ -69,7 +69,7 @@ class FriedmanRafsky(IndependenceTest):
 
     def statistic(self, x, y):
         r"""
-        Helper function that calculates the Friedman Rafksy test statistic.
+        Helper function that calculates the Friedman Rafksy test statistic. 
 
         Parameters
         ----------
@@ -83,7 +83,7 @@ class FriedmanRafsky(IndependenceTest):
         Returns
         -------
         stat : float
-            The computed Friedman Rafsky statistic. 
+            The computed Friedman Rafsky statistic. A value between ``2`` and ``n``.
         """
         x = np.transpose(x)
         labels = np.transpose(y)
@@ -102,7 +102,7 @@ class FriedmanRafsky(IndependenceTest):
         random_state=None,
     ):
         r"""
-        Calculates the Friedman Rafsky test statistic and p-value. A value between ``2`` and ``n``.
+        Calculates the Friedman Rafsky test statistic and p-value. 
 
         Parameters
         ----------

--- a/tutorials/independence.py
+++ b/tutorials/independence.py
@@ -370,8 +370,10 @@ plt.show()
 # As such, we see that this set of data contains 3 such runs, and again by randomizing the
 # labels of each data point we can determine the test statistic and p-value for the hypothesis
 # that to determine the randomness of our combined sample.
-# It's worth noting that X and Y have the same number of samples, just that they posess the same number of multivariate
-# features. Lastly, labels for X and Y need not be 0 and 1, they just need be consistent across samples.
+# It's worth noting that X and Y need not have the same number of samples, just that they posess the same number of 
+# multivariate features. Lastly, labels for X and Y need not be 0 and 1, they just need be consistent across samples.
 # These tests runs like :ref:`any other test<general indep>`.
+#
+# Test statistic range: :math:`[2, m+n]`
 #
 # .. _[1]: https://link.springer.com/article/10.1007/s10182-020-00378-1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
"Add Range of Friedman Rafsky Test Statistic #329
https://github.com/neurodata/hyppo/issues/329
#### Type of change
<!--Bug, Documentation, Feature Request-->
Documentation
#### What does this implement/fix?
<!--Please explain your changes.-->
Adds the range of the Friedman Rafsky (uncorrected) test statistic 
#### Additional information
<!--Any additional information you think is important.-->
Some verification of the range of expected values can been seen in [this notebook](https://github.com/oakla/hyppo-independence-statistic-ranges/blob/main/sim-range-tests/Friedman_Rafsky/sim_testing.ipynb)