### PR TITLE
Fix typo in distance covariance equation

### DIFF
--- a/hyppo/independence/dcorr.py
+++ b/hyppo/independence/dcorr.py
@@ -56,7 +56,7 @@ class Dcorr(IndependenceTest):
 
     .. math::
 
-        \mathrm{Dcov}^b_n (x, y) = \frac{1}{n^2} \mathrm{tr} (D^x H D^y H)
+        \mathrm{Dcov}^b_n (x, y) = \frac{1}{n^2} \mathrm{tr} (H D^x H H D^y H)
 
     where :math:`\mathrm{tr} (\cdot)` is the trace operator and :math:`H` is
     defined as :math:`H = I - (1/n) J` where :math:`I` is the identity matrix


### PR DESCRIPTION

<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### Type of change
<!--Bug, Documentation, Feature Request-->

Documentation change

#### What does this implement/fix?
<!--Please explain your changes.-->

The distance covariance equation needs the distance matrix to be both left and right multiplied by the centering matrix `H`.


#### Additional information
<!--Any additional information you think is important.-->