### PR TITLE
bugfix: reduce maximum dependency of numpy to 1.23.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.17
+numpy>=1.17, <=1.23.5
 scipy>=1.4.0
 numba>=0.46
 scikit-learn>=0.22


### PR DESCRIPTION
bugfix: reduce maximum dependency of NumPy to 1.23.5 to maintain compatibility with numba & NumPy libraries

<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes https://github.com/neurodata/hyppo/issues/344
Closes #325 

#### Type of change
<!--Bug, Documentation, Feature Request-->
Bugfix: Added support helps in maintaining compatibility between NumPy & Numba packages
<br>
#### What does this implement/fix?
<!--Please explain your changes.-->
```
SystemError: initialization of _internal failed without raising an exception
```
This is a common error when using NumPy>=1.24.0 ❌❌
Since the `requirements.txt` file specifies numpy>=1.17 it installs the latest supported version of numpy==1.24.1, causing the conflict & throwing an exception. 
<br>

Adding a check to restrict the maximum version of numpy to be <=1.23.5  ✅✅ will solve the issue

Here is the stack overflow [link](https://stackoverflow.com/questions/74947992/how-to-remove-the-error-systemerror-initialization-of-internal-failed-without) to affirm the same


#### Additional information
<!--Any additional information you think is important.-->
Please review & let me know of additional changes. Happy Coding 😇😇😇