### PR TITLE
Fix type checking

### DIFF
--- a/hyppo/tools/common.py
+++ b/hyppo/tools/common.py
@@ -367,7 +367,7 @@ def check_perm_blocks_dim(perm_blocks, y):
 
 def check_perm_block(perm_block):
     # checks a hierarchy level of perm_blocks for proper exchangeability
-    if not isinstance(perm_block[0], int):
+    if not np.issubdtype(type(perm_block[0]), np.integer):
         unique, perm_blocks, counts = np.unique(
             perm_block, return_counts=True, return_inverse=True
         )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### Type of change
Fixed a type check in perm blocks

#### What does this implement/fix?
`np.integer` encompasses all integer types including python `int`. Changes to check if its any type of `int` rather than just python `int`. 

#### Additional information
<!--Any additional information you think is important.-->