### PR TITLE
Parameter noise for function _square_dimond

### DIFF
--- a/hyppo/tools/indep_sim.py
+++ b/hyppo/tools/indep_sim.py
@@ -735,7 +735,7 @@ def _square_diamond(n, p, noise=False, low=-1, high=1, period=-np.pi / 2):
     sig = np.identity(p)
     gauss_noise = np.random.multivariate_normal(np.zeros(p), sig, size=n)
 
-    x = u * np.cos(period) + v * np.sin(period) + 0.05 * p * gauss_noise
+    x = u * np.cos(period) + v * np.sin(period) + 0.05 * p * gauss_noise * noise
     y = -u * np.sin(period) + v * np.cos(period)
 
     return x, y


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes- #358

#### Type of change
<!--Bug, Documentation, Feature Request-->
Bug

#### What does this implement/fix?
<!--Please explain your changes.-->
Parameter "noise" for function _square_diamond()
in the _square_diamond
the Parameter x
before 
x = u * np.cos(period) + v * np.sin(period) + 0.05 * p * gauss_noise
After
x = u * np.cos(period) + v * np.sin(period) + 0.05 * p * gauss_noise * noise
now x has the expected output

#### Additional information
<!--Any additional information you think is important.-->