### PR TITLE
[Issue 341] Updated energy stats calculation, aligned with dcor package results, and added unit test

### DIFF
--- a/hyppo/ksample/energy.py
+++ b/hyppo/ksample/energy.py
@@ -1,9 +1,10 @@
-from ..independence.dcorr import _dcov
+from ..independence.dcorr import _dcov, _fast_1d_dcov
 from ..tools import compute_dist
 from ._utils import _CheckInputs
 from .base import KSampleTest, KSampleTestOutput
 from .ksamp import KSample
-
+import numpy as np
+import dcor
 
 class Energy(KSampleTest):
     r"""
@@ -106,16 +107,18 @@ class Energy(KSampleTest):
         stat : float
             The computed Energy statistic.
         """
-        distx = x
-        disty = y
+        dataMatrix = np.concatenate([x, y])
+        labelMatrix = np.concatenate([np.zeros(len(x)), np.ones(len(y))])
         n = x.shape[0]
         m = y.shape[0]
-
-        distx, disty = compute_dist(x, y, metric=self.compute_distance, **self.kwargs)
+        
+        dcov = dcor.distance_covariance_sqr(dataMatrix, labelMatrix)
 
         # exact equivalence transformation Dcorr and Energy
         stat = (
-            _dcov(distx, disty, self.bias) * (2 * (n**2) * (m**2)) / ((n + m) ** 4)
+            
+            dcov / ((2 * (n**2) * (m**2)) / ((n + m) ** 4))
+
         )
         self.stat = stat
 

--- a/hyppo/ksample/energy.py
+++ b/hyppo/ksample/energy.py
@@ -1,4 +1,4 @@
-from ..independence.dcorr import _dcov, _fast_1d_dcov
+from ..independence.dcorr import _dcov
 from ..tools import compute_dist
 from ._utils import _CheckInputs
 from .base import KSampleTest, KSampleTestOutput

--- a/hyppo/ksample/tests/test_ksamp.py
+++ b/hyppo/ksample/tests/test_ksamp.py
@@ -3,7 +3,7 @@ import pytest
 from numpy.testing import assert_almost_equal, assert_raises
 
 from ...tools import power, rot_ksamp
-from .. import KSample
+from .. import KSample, Energy
 
 
 class TestKSample:
@@ -45,6 +45,13 @@ class TestKSample:
         assert stat == stat2
         assert pvalue == pvalue2
 
+    def test_energy(self):
+        x = np.arange(200.0)
+        y = x**2
+        ksample_energy_stat = Energy(bias=True).statistic(x[:, None], y[:, None])
+        energy_stat = 12950.98
+
+        assert_almost_equal(ksample_energy_stat, energy_stat, decimal=2)
 
 class TestKSampleErrorWarn:
     """Tests errors and warnings derived from MGC."""


### PR DESCRIPTION
…ge results, and added unit test

<!--
Thanks for contributing a pull request!
-->

#### Reference issue
Made changes to resolve [Issue-341](https://github.com/neurodata/hyppo/issues/341)

#### Type of change
Updated ksample/energy.py file by changing the energy stats calculation, following along [the paper theorem-2](https://arxiv.org/pdf/1910.08883.pdf). Added unit test.

#### What does this implement/fix?
After the change, the energy statistics result from ksample follows along with paper calculation and dcor package's energy distance calculation.

#### Additional information
Please only consider the last commit and ignore the previous two as they are redundant. Thank you.