### PR TITLE
Improve speed of FriedmanRafsky code

### DIFF
--- a/hyppo/independence/friedman_rafsky.py
+++ b/hyppo/independence/friedman_rafsky.py
@@ -1,7 +1,6 @@
 import random
 from typing import NamedTuple
 
-from numba import jit
 import numpy as np
 
 from .base import IndependenceTest
@@ -214,7 +213,7 @@ def prim(weight_mat, labels):
     return MST_connections
 
 
-@jit(nopython=True, cache=True)
+
 def MST(x, labels):  # pragma: no cover
     r"""
     Helper function to read input data and calculate Euclidean distance

--- a/hyppo/independence/friedman_rafsky.py
+++ b/hyppo/independence/friedman_rafsky.py
@@ -178,7 +178,6 @@ def prim(weight_mat, labels):
     MST_connections : list of int
         List of pairs of nodes connected in final MST.
     """
-    INF = 9999999
     V = len(labels)
     selected = np.zeros(len(labels))
     no_edge = 0

--- a/hyppo/independence/friedman_rafsky.py
+++ b/hyppo/independence/friedman_rafsky.py
@@ -161,7 +161,7 @@ def _num_runs(labels, MST_connections):
     return run_count
 
 
-@jit(nopython=True, cache=True)  # pragma: no cover
+
 def prim(weight_mat, labels):
     r"""
     Helper function to read weighted matrix input and compute minimum
@@ -190,15 +190,23 @@ def prim(weight_mat, labels):
         minimum = INF
         x = 0
         y = 0
-        for i in range(V):
-            if selected[i]:
-                for j in range(V):
-                    if (not selected[j]) and weight_mat[i][j]:
-                        # not in selected and there is an edge
-                        if minimum > weight_mat[i][j]:
-                            minimum = weight_mat[i][j]
-                            x = i
-                            y = j
+        rows_true = np.where(selected)[0]
+        columns_false = np.where(np.logical_not(selected))[0]
+        """
+        based on choose rows with True and columns with False make indexes 
+        'ind'  to fetch values from an array 'weight_mat'.
+        """
+        ind = np.array(np.meshgrid(rows_true, columns_false, indexing='ij')).reshape(2, -1)
+        sample = weight_mat[ind[0], ind[1]]
+        """
+        'i_min' index of the minimum from sample. With the help of which we
+         extract the desired index corresponding to the 'weight_mat' array.
+        """
+        i_min = np.where((sample < minimum) & (sample == np.min(sample[np.nonzero(sample)])))
+
+        x = ind[0][i_min[0]][0]
+        y = ind[1][i_min[0]][0]
+
         MST_connections.append([x, y])
         selected[y] = True
         no_edge += 1

--- a/hyppo/independence/friedman_rafsky.py
+++ b/hyppo/independence/friedman_rafsky.py
@@ -201,7 +201,7 @@ def prim(weight_mat, labels):
         'i_min' index of the minimum from sample. With the help of which we
          extract the desired index corresponding to the 'weight_mat' array.
         """
-        i_min = np.where((sample < minimum) & (sample == np.min(sample[np.nonzero(sample)])))
+        i_min = np.where(sample == np.min(sample[np.nonzero(sample)]))
 
         x = ind[0][i_min[0]][0]
         y = ind[1][i_min[0]][0]

--- a/hyppo/independence/friedman_rafsky.py
+++ b/hyppo/independence/friedman_rafsky.py
@@ -186,9 +186,6 @@ def prim(weight_mat, labels):
     MST_connections = []
 
     while no_edge < V - 1:
-        minimum = INF
-        x = 0
-        y = 0
         rows_true = np.where(selected)[0]
         columns_false = np.where(np.logical_not(selected))[0]
         """


### PR DESCRIPTION
Closes issue #402 

After discussion [here:](https://github.com/neurodata/hyppo/issues/402)

I would like to improve the function code: prim from the class: FriedmanRafsky.

Since the function has a decorator: `@jit(nopython=True, cache=True) `using numba, the first start is warming up and lasts a long time. For a 100 x 100 array, it turned out 30 - 120 times slower than my version on the first run. True, subsequent launches are about 5 times faster than my version.

If you do not use numba, then the speedup is about 29 times with an array of 500 x 500. The speedup starts with an array size starting from 20 x 20.