### PR TITLE
Resolve CCA Incorrect Statistics #413

### DIFF
--- a/hyppo/independence/cca.py
+++ b/hyppo/independence/cca.py
@@ -73,13 +73,13 @@ class CCA(IndependenceTest):
 
         # if 1-d, don't calculate the svd
         if varx.size == 1 or vary.size == 1 or covar.size == 1:
-            covar = np.sum(covar**2)
-            stat = covar / np.sqrt(np.sum(varx**2) * np.sum(vary**2))
+            covar = np.sum(covar)
+            stat = covar / np.sqrt(np.sum(varx) * np.sum(vary))
         else:
-            covar = np.sum(np.linalg.svd(covar, 1)[1] ** 2)
+            covar = np.sum(np.linalg.svd(covar, compute_uv=False) ** 2)
             stat = covar / np.sqrt(
-                np.sum(np.linalg.svd(varx, 1)[1] ** 2)
-                * np.sum(np.linalg.svd(vary, 1)[1] ** 2)
+                np.sum(np.linalg.svd(varx, compute_uv=False) ** 2)
+                * np.sum(np.linalg.svd(vary, compute_uv=False) ** 2)
             )
         self.stat = stat
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
Closes CCA Incorrect Statistics #413

#### Type of change
Bug fix

#### What does this implement/fix?
Fixed bug in statistic method CCA implementation where it was incorrectly calculating the correlation statistic for 1-D data. Now, when the input only has one dimension, it uses Pearson's correlation instead of SVD.

#### Additional information
This was an assignment for a course to get familiar with open source. I'm sure I missed a lot with the development process, but hopefully this helps !(?)