### PR TITLE
Bug Fix: Remove ‘past’ dependency from fssd.py and test_density.py (#423)

### DIFF
--- a/hyppo/kgof/tests/test_density.py
+++ b/hyppo/kgof/tests/test_density.py
@@ -1,6 +1,5 @@
 import numpy as np
 from numpy import testing
-from past.utils import old_div
 from scipy.linalg.misc import norm
 
 from ..datasource import DSNormal, DSIsotropicNormal
@@ -61,10 +60,10 @@ class TestNormal:
         norm = Normal(mean, cov)
         log_dens = norm.log_den(X)
         E, V = np.linalg.eigh(cov)
-        prec = np.dot(np.dot(V, np.diag(old_div(1.0, E))), V.T)
+        prec = np.dot(np.dot(V, np.diag(1.0 / E)), V.T)
         X0 = X - mean
         X0prec = np.dot(X0, prec)
-        my_log_dens = old_div(-np.sum(X0prec * X0, 1), 2.0)
+        my_log_dens = -np.sum(X0prec * X0, 1) / 2.0
 
         ds_norm = DSNormal(test_mean, cov)
         ds_norm.sample(n=10)


### PR DESCRIPTION
Fixes #423. Removed `past.utils.old_div` from `fssd.py` and `test_density.py` to eliminate `ModuleNotFoundError` in Python 3.9+. Replaced `old_div` with `/`, and adjusted `simulate_null_dist` in `fssd.py` to use integer division (`//`) to fix a `TypeError` in tests. Verified locally with `pytest hyppo/kgof/tests/`—all 12 tests passed on Python 3.12.

Changes:
- `fssd.py`: Removed `from past.utils import old_div`, replaced 8 `old_div` instances with `/`, fixed `d = len(eigs) / J` to `d = len(eigs) // J`.
- `test_density.py`: Removed `from past.utils import old_div`, replaced 2 `old_div` instances with `/`.
- Tested: `python -m pytest hyppo/kgof/tests/` shows 12/12 passed.