### PR TITLE
fix of negative unbiased dcov for chi-square test

### DIFF
--- a/hyppo/independence/dcorr.py
+++ b/hyppo/independence/dcorr.py
@@ -434,7 +434,7 @@ def _dcorr(distx, disty, bias=False, is_fast=False):  # pragma: no cover
         vary = _dcov(disty, disty, bias=bias, only_dcov=False)
 
     # stat is 0 with negative variances (would make denominator undefined)
-    if varx <= 0 or vary <= 0 or covar <= 0:
+    if varx <= 0 or vary <= 0 or (covar <= 0 and bias):
         stat = 0
 
     # calculate generalized test statistic

--- a/hyppo/independence/dcorr.py
+++ b/hyppo/independence/dcorr.py
@@ -434,6 +434,7 @@ def _dcorr(distx, disty, bias=False, is_fast=False):  # pragma: no cover
         vary = _dcov(disty, disty, bias=bias, only_dcov=False)
 
     # stat is 0 with negative variances (would make denominator undefined)
+    # if unbiased dcov, then negative values may be suitable for an asymptotic test
     if varx <= 0 or vary <= 0 or (covar <= 0 and bias):
         stat = 0
 

--- a/hyppo/independence/tests/test_kmerf.py
+++ b/hyppo/independence/tests/test_kmerf.py
@@ -21,8 +21,8 @@ class TestKMERFStat(object):
             ),  # test spiral simulation
             (
                 multimodal_independence,
-                0.0,
-                0.31731050786291115,
+                -0.0365162074938057,
+                1.0,
             ),  # test independence simulation
         ],
     )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
Closes issue [#429](https://github.com/neurodata/hyppo/issues/429)

#### Type of change
Bug

#### What does this implement/fix?
In the `_dcorr` function within dcorr.py, the condition `varx <= 0 or vary <= 0 or covar <= 0` should be properly handled. Currently, when condition `covar <= 0` occur, the function `chi2_approx` in common.py generates inflated p-values equal to 1, even when `stat * n + 1` could be positive (even if `stat` is negative).

This leads to incorrect statistical inference as valid test statistics are being discarded due to overly strict conditions.
