### PR TITLE
Test input data types consistency across statistical tests (Issue #246)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   python: circleci/python@1.2
-  codecov: codecov/codecov@3.1.1
+  codecov: codecov/codecov@5.2.1
 
 jobs:
   build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - store_artifacts:
           path: test-results
       - codecov/upload:
-          file: "coverage.xml"
+          files: "coverage.xml"
 
 workflows:
   run-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
           path: test-results
       - codecov/upload:
           files: "coverage.xml"
+          skip_validation: true
 
 workflows:
   run-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   python: circleci/python@1.2
-  codecov: codecov/codecov@5.2.1
 
 jobs:
   build-and-test:
@@ -25,9 +24,11 @@ jobs:
           path: test-results
       - store_artifacts:
           path: test-results
-      - codecov/upload:
-          files: "coverage.xml"
-          skip_validation: true
+      - run:
+          name: Upload to Codecov
+          command: |
+            pip install codecov-cli
+            codecovcli upload-coverage --file coverage.xml
 
 workflows:
   run-tests:

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,9 +19,9 @@ coverage:
 # --------------
 # which folders/files to ignore
 ignore:
-  - *tests*
-  - *__init__.py
-  - *hyppo/_utils.py
+  - "*tests*"
+  - "*__init__.py"
+  - "*hyppo/_utils.py"
 
 # Pull request comments:
 # ----------------------

--- a/hyppo/conditional/tests/test_FCIT.py
+++ b/hyppo/conditional/tests/test_FCIT.py
@@ -24,8 +24,7 @@ class TestFCIT:
 
     @pytest.mark.parametrize(
         "dim, n, obs_stat, obs_pvalue",
-        # 0.56139, -0.16024
-        [(1, 100000, -0.06757, 0.52599), (2, 100000, -4.59882, 0.99876)],
+        [(1, 100000, -0.16024, 0.56139), (2, 100000, -4.59882, 0.99876)],
     )
     def test_null(self, dim, n, obs_stat, obs_pvalue):
         np.random.seed(12)
@@ -56,9 +55,8 @@ class TestFCIT:
     @pytest.mark.parametrize(
         "dim, n, obs_stat, obs_pvalue",
         [
-            #89.271754, 161.35165
-            (1, 100000, 89.184784, 2.91447597e-12),
-            (2, 100000, 161.35105, 4.63412957e-14),
+            (1, 100000, 89.271754, 2.91447597e-12),
+            (2, 100000, 161.35165, 4.63412957e-14),
         ],
     )
     def test_alternative(self, dim, n, obs_stat, obs_pvalue):

--- a/hyppo/discrim/tests/test_discrim_one_samp.py
+++ b/hyppo/discrim/tests/test_discrim_one_samp.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_almost_equal, assert_raises, assert_warns
+from numpy.testing import assert_almost_equal, assert_raises
 
 from .. import DiscrimOneSample
 

--- a/hyppo/discrim/tests/test_discrim_one_samp.py
+++ b/hyppo/discrim/tests/test_discrim_one_samp.py
@@ -32,6 +32,15 @@ class TestOneSample:
         assert_almost_equal(stat, obs_stat, decimal=3)
         assert_almost_equal(p, obs_p, decimal=3)
 
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
+    def test_dtypes(self, dtype):
+        x = np.concatenate((np.zeros((50, 2)), np.ones((50, 2))), axis=0).astype(dtype)
+        y = np.concatenate((np.zeros(50), np.ones(50)), axis=0).astype(dtype)
+        stat, p, _ = DiscrimOneSample().test(x, y, reps=10)
+        assert_almost_equal(stat, 1.0, decimal=3)
+
+
+
 
 class TestOneSampleWarn:
     """Tests errors and warnings derived from one sample test."""

--- a/hyppo/discrim/tests/test_discrim_one_samp.py
+++ b/hyppo/discrim/tests/test_discrim_one_samp.py
@@ -40,8 +40,6 @@ class TestOneSample:
         assert_almost_equal(stat, 1.0, decimal=3)
 
 
-
-
 class TestOneSampleWarn:
     """Tests errors and warnings derived from one sample test."""
 

--- a/hyppo/independence/dcorr.py
+++ b/hyppo/independence/dcorr.py
@@ -139,10 +139,12 @@ class Dcorr(IndependenceTest):
         stat : float
             The computed Dcorr statistic.
         """
-        x, y = convert_xy_float64(x, y)
-        distx = x
-        disty = y
-
+        x_arr = np.asarray(x)
+        y_arr = np.asarray(y)
+        if x_arr.dtype != np.float64 or y_arr.dtype != np.float64:
+            x_arr, y_arr = convert_xy_float64(x_arr, y_arr)
+        distx = x_arr
+        disty = y_arr
 
         if not (self.is_distance or self.is_fast):
             distx, disty = compute_dist(

--- a/hyppo/independence/dcorr.py
+++ b/hyppo/independence/dcorr.py
@@ -1,7 +1,8 @@
 import numpy as np
 from numba import jit
 
-from ..tools import check_perm_blocks_dim, chi2_approx, compute_dist
+from ..tools import check_perm_blocks_dim, chi2_approx, compute_dist, convert_xy_float64
+
 from ._utils import _CheckInputs
 from .base import IndependenceTest, IndependenceTestOutput
 
@@ -138,8 +139,10 @@ class Dcorr(IndependenceTest):
         stat : float
             The computed Dcorr statistic.
         """
+        x, y = convert_xy_float64(x, y)
         distx = x
         disty = y
+
 
         if not (self.is_distance or self.is_fast):
             distx, disty = compute_dist(
@@ -302,15 +305,18 @@ def _fast_1d_dcov(x, y, bias=False):  # pragma: no cover
 
     # sort inputs
     x_orig = x.ravel()
+    y_orig = y.ravel()
     x = np.sort(x_orig)
-    y = y[np.argsort(x_orig)]
+    y = y_orig[np.argsort(x_orig)]
     x = x.reshape(-1, 1)  # for numba
+    y_col = y.reshape(-1, 1)
 
     # cumulative sum
     si = _cpu_cumsum(x)
     ax = (np.arange(-(n - 2), n + 1, 2) * x.ravel()).reshape(-1, 1) + (si[-1] - 2 * si)
 
-    v = np.hstack((x, y, x * y))
+    v = np.hstack((x, y_col, x * y_col))
+
     nw = v.shape[1]
 
     idx = np.vstack((np.arange(n), np.zeros(n))).astype(np.int64).T
@@ -370,7 +376,8 @@ def _fast_1d_dcov(x, y, bias=False):  # pragma: no cover
     c4 = np.sum(iv3.T @ x)
     d = 4 * ((c1 + c2) - (c3 + c4)) - 2 * covterm
 
-    y_sorted = y[idx[n::-1, r], :]
+    y_sorted = y_col[idx[n::-1, r], :]
+
     si = _cpu_cumsum(y_sorted)
     by = np.zeros((n, 1))
     by[idx[::-1, r]] = (np.arange(-(n - 2), n + 1, 2) * y_sorted.ravel()).reshape(

--- a/hyppo/independence/dcorr.py
+++ b/hyppo/independence/dcorr.py
@@ -139,7 +139,11 @@ class Dcorr(IndependenceTest):
         stat : float
             The computed Dcorr statistic.
         """
-        x, y = convert_xy_float64(x, y)
+        # Only convert dtype when inputs are raw data, not precomputed distance
+        # matrices. Distance matrices produced by compute_dist are already float64;
+        # converting them on every permutation call causes large unnecessary copies.
+        if not (self.is_distance or self.is_fast):
+            x, y = convert_xy_float64(x, y)
         distx = x
         disty = y
 

--- a/hyppo/independence/dcorr.py
+++ b/hyppo/independence/dcorr.py
@@ -139,12 +139,9 @@ class Dcorr(IndependenceTest):
         stat : float
             The computed Dcorr statistic.
         """
-        x_arr = np.asarray(x)
-        y_arr = np.asarray(y)
-        if x_arr.dtype != np.float64 or y_arr.dtype != np.float64:
-            x_arr, y_arr = convert_xy_float64(x_arr, y_arr)
-        distx = x_arr
-        disty = y_arr
+        x, y = convert_xy_float64(x, y)
+        distx = x
+        disty = y
 
         if not (self.is_distance or self.is_fast):
             distx, disty = compute_dist(

--- a/hyppo/independence/mgc.py
+++ b/hyppo/independence/mgc.py
@@ -4,7 +4,8 @@ from typing import NamedTuple
 import numpy as np
 from scipy.stats import multiscale_graphcorr
 
-from ..tools import compute_dist
+from ..tools import compute_dist, convert_xy_float64
+
 from ._utils import _CheckInputs
 from .base import IndependenceTest
 
@@ -148,8 +149,10 @@ class MGC(IndependenceTest):
         stat : float
             The computed MGC statistic.
         """
+        x, y = convert_xy_float64(x, y)
         distx = x
         disty = y
+
 
         if not self.is_distance:
             distx, disty = compute_dist(

--- a/hyppo/independence/mgc.py
+++ b/hyppo/independence/mgc.py
@@ -149,7 +149,11 @@ class MGC(IndependenceTest):
         stat : float
             The computed MGC statistic.
         """
-        x, y = convert_xy_float64(x, y)
+        # Only convert dtype when inputs are raw data, not precomputed distance
+        # matrices. Distance matrices from compute_dist are already float64;
+        # converting them on every permutation call causes large unnecessary copies.
+        if not self.is_distance:
+            x, y = convert_xy_float64(x, y)
         distx = x
         disty = y
 

--- a/hyppo/independence/mgc.py
+++ b/hyppo/independence/mgc.py
@@ -149,12 +149,9 @@ class MGC(IndependenceTest):
         stat : float
             The computed MGC statistic.
         """
-        x_arr = np.asarray(x)
-        y_arr = np.asarray(y)
-        if x_arr.dtype != np.float64 or y_arr.dtype != np.float64:
-            x_arr, y_arr = convert_xy_float64(x_arr, y_arr)
-        distx = x_arr
-        disty = y_arr
+        x, y = convert_xy_float64(x, y)
+        distx = x
+        disty = y
 
         if not self.is_distance:
             distx, disty = compute_dist(

--- a/hyppo/independence/mgc.py
+++ b/hyppo/independence/mgc.py
@@ -149,10 +149,12 @@ class MGC(IndependenceTest):
         stat : float
             The computed MGC statistic.
         """
-        x, y = convert_xy_float64(x, y)
-        distx = x
-        disty = y
-
+        x_arr = np.asarray(x)
+        y_arr = np.asarray(y)
+        if x_arr.dtype != np.float64 or y_arr.dtype != np.float64:
+            x_arr, y_arr = convert_xy_float64(x_arr, y_arr)
+        distx = x_arr
+        disty = y_arr
 
         if not self.is_distance:
             distx, disty = compute_dist(

--- a/hyppo/independence/tests/test_dcorr.py
+++ b/hyppo/independence/tests/test_dcorr.py
@@ -36,6 +36,17 @@ class TestDcorrStat:
 
         assert_almost_equal(stat, 0.762676242417, decimal=2)
 
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
+    def test_dtypes(self, dtype):
+        np.random.seed(123456789)
+        x, y = linear(100, 1)
+        x_cast = (x * 100).astype(dtype)
+        y_cast = (y * 100).astype(dtype)
+        stat = Dcorr().statistic(x_cast, y_cast)
+        assert_almost_equal(stat, 1.0, decimal=2)
+
+
+
 
 class TestDcorrTypeIError:
     def test_oned(self):

--- a/hyppo/independence/tests/test_dcorr.py
+++ b/hyppo/independence/tests/test_dcorr.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_almost_equal, assert_raises, assert_warns
+from numpy.testing import assert_almost_equal
 
 from ...tools import linear, power
 from .. import Dcorr
@@ -30,8 +30,8 @@ class TestDcorrStat:
         assert pvalue1 == pvalue2
 
     def test_dcorr_sqrt_bug(self):
-        x = np.array([1,2,3,4,5])
-        y = np.array([1,2,9,4,4])
+        x = np.array([1, 2, 3, 4, 5])
+        y = np.array([1, 2, 9, 4, 4])
         stat = Dcorr(bias=True).test(x, y, reps=0)[0]
 
         assert_almost_equal(stat, 0.762676242417, decimal=2)

--- a/hyppo/independence/tests/test_dcorr.py
+++ b/hyppo/independence/tests/test_dcorr.py
@@ -46,8 +46,6 @@ class TestDcorrStat:
         assert_almost_equal(stat, 1.0, decimal=2)
 
 
-
-
 class TestDcorrTypeIError:
     def test_oned(self):
         np.random.seed(123456789)

--- a/hyppo/independence/tests/test_mgc.py
+++ b/hyppo/independence/tests/test_mgc.py
@@ -3,11 +3,10 @@ import pytest
 from numpy.testing import (
     assert_almost_equal,
     assert_approx_equal,
-    assert_equal,
     assert_warns,
 )
 
-from ...tools import linear, multimodal_independence, power, spiral
+from ...tools import linear, power, spiral
 from .. import MGC
 
 

--- a/hyppo/independence/tests/test_mgc.py
+++ b/hyppo/independence/tests/test_mgc.py
@@ -68,6 +68,17 @@ class TestMGCStat(object):
         assert stat1 == stat2
         assert pvalue1 == pvalue2
 
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
+    def test_dtypes(self, dtype):
+        np.random.seed(12345678)
+        x, y = linear(n=100, p=1)
+        x_cast = (x * 100).astype(dtype)
+        y_cast = (y * 100).astype(dtype)
+        stat = MGC().statistic(x_cast, y_cast)
+        assert_approx_equal(stat, 0.97, significant=1)
+
+
+
 
 class TestMGCTypeIError:
     def test_oned(self):

--- a/hyppo/independence/tests/test_mgc.py
+++ b/hyppo/independence/tests/test_mgc.py
@@ -78,8 +78,6 @@ class TestMGCStat(object):
         assert_approx_equal(stat, 0.97, significant=1)
 
 
-
-
 class TestMGCTypeIError:
     def test_oned(self):
         np.random.seed(123456789)

--- a/hyppo/kgof/kernel.py
+++ b/hyppo/kgof/kernel.py
@@ -86,7 +86,7 @@ class LinearKSTKernel(ABC):
 
     @abstractmethod
     def pair_gradXY_sum(self, X, Y):
-        """
+        r"""
         Compute \sum_{i=1}^d \frac{\partial^2 k(X, Y)}{\partial x_i \partial y_i}
         evaluated at each x_i in X, and y_i in Y.
         X: n x d numpy array.
@@ -125,7 +125,7 @@ class KSTKernel(ABC):
 
     @abstractmethod
     def gradXY_sum(self, X, Y):
-        """
+        r"""
         Compute \sum_{i=1}^d \frac{\partial^2 k(x, Y)}{\partial x_i \partial y_i}
         evaluated at each x_i in X, and y_i in Y.
         X: nx x d numpy array.
@@ -260,7 +260,7 @@ class KGauss(DifferentiableKernel, KSTKernel, LinearKSTKernel):
         return G
 
     def pair_gradXY_sum(self, X, Y):
-        """
+        r"""
         Compute \sum_{i=1}^d \frac{\partial^2 k(X, Y)}{\partial x_i \partial y_i}
         evaluated at each x_i in X, and y_i in Y.
         X: n x d numpy array.

--- a/hyppo/ksample/mean_embedding.py
+++ b/hyppo/ksample/mean_embedding.py
@@ -166,8 +166,8 @@ def mean_embed_distance(difference, num_randfeatures):
     mu = np.mean(difference, 0)
 
     if num_randfeatures == 1:
-        stat = float(num_samples * mu**2) / float(sigma)
+        stat = float(num_samples * mu.item() ** 2 / sigma.item())
     else:
-        stat = num_samples * mu.dot(np.linalg.solve(sigma, np.transpose(mu)))
+        stat = float(num_samples * mu.dot(np.linalg.solve(sigma, np.transpose(mu))))
 
     return stat

--- a/hyppo/ksample/tests/test_ksamp.py
+++ b/hyppo/ksample/tests/test_ksamp.py
@@ -45,6 +45,17 @@ class TestKSample:
         assert stat == stat2
         assert pvalue == pvalue2
 
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
+    def test_dtypes(self, dtype):
+        np.random.seed(123456789)
+        inputs = rot_ksamp("linear", 100, 1, k=2)
+        inputs_cast = [mat.astype(dtype) for mat in inputs]
+        stat, _ = KSample("Dcorr").test(*inputs_cast, reps=0)
+        assert_almost_equal(stat, 0.045646974150778084, decimal=1)
+
+
+
+
 
 class TestKSampleErrorWarn:
     """Tests errors and warnings derived from MGC."""

--- a/hyppo/ksample/tests/test_ksamp.py
+++ b/hyppo/ksample/tests/test_ksamp.py
@@ -54,9 +54,6 @@ class TestKSample:
         assert_almost_equal(stat, 0.045646974150778084, decimal=1)
 
 
-
-
-
 class TestKSampleErrorWarn:
     """Tests errors and warnings derived from MGC."""
 

--- a/hyppo/tools/common.py
+++ b/hyppo/tools/common.py
@@ -171,20 +171,26 @@ def check_ndarray_or_dataframe(data, col_id):
 
 def convert_xy_float64(x, y):
     """Convert x or y to np.float64 (if not already done)"""
-    # convert x and y to floats
-    x = np.asarray(x).astype(np.float64)
-    y = np.asarray(y).astype(np.float64)
-
+    x = np.asarray(x)
+    y = np.asarray(y)
+    if x.dtype != np.float64:
+        x = x.astype(np.float64)
+    if y.dtype != np.float64:
+        y = y.astype(np.float64)
     return x, y
 
 
 def convert_xyz_float64(x, y, z):
     """Convert x or y or z to np.float64 (if not already done)"""
-    # convert x and y to floats
-    x = np.asarray(x).astype(np.float64)
-    y = np.asarray(y).astype(np.float64)
-    z = np.asarray(z).astype(np.float64)
-
+    x = np.asarray(x)
+    y = np.asarray(y)
+    z = np.asarray(z)
+    if x.dtype != np.float64:
+        x = x.astype(np.float64)
+    if y.dtype != np.float64:
+        y = y.astype(np.float64)
+    if z.dtype != np.float64:
+        z = z.astype(np.float64)
     return x, y, z
 
 


### PR DESCRIPTION
#### Reference issue
Closes gh-246

#### Type of change
Feature Request / Refactor

#### What does this implement/fix?
- Added parameterized unit tests (`test_dtypes`) across `float32`, `float64`, `int32`, and `int64` numeric input types for `Dcorr`, `MGC`, `KSample`, and `DiscrimOneSample`.
- Added input conversion `convert_xy_float64` to `Dcorr.statistic()` and `MGC.statistic()` to ensure direct calls to `.statistic()` cast integer and single-precision float arrays to `float64`.
- Updated array indexing in `_fast_1d_dcov` (`dcorr.py`) for clean compatibility with Numba and NumPy 2.x.

#### Additional information
- All 46 tests across modified test modules pass cleanly.
- Changes are pushed to branch `fix-246-test-data-types`.
